### PR TITLE
Fix all instances of variable length arrays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ if(STATIC)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bstatic,--whole-archive -lwinpthread -Wl,--no-whole-archive")
 endif(STATIC)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=vla")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=vla")
+
 target_include_directories(UDBM
     PRIVATE
         # where the library itself will look for its internal headers

--- a/src/mingraph_equal.c
+++ b/src/mingraph_equal.c
@@ -291,9 +291,11 @@ static bool mingraph_isAnalyzedDBMEqualToMinBitMatrix32(const raw_t* dbm, cindex
  */
 static bool mingraph_isEqualToMinBitMatrix32(const raw_t* dbm, cindex_t dim, const int32_t* mingraph)
 {
-    uint32_t bitMatrix[bits2intsize(dim * dim)];
+    uint32_t* bitMatrix = (uint32_t*)calloc(bits2intsize(dim * dim), sizeof(uint32_t));
     size_t nbConstraints = dbm_analyzeForMinDBM(dbm, dim, bitMatrix);
-    return mingraph_isAnalyzedDBMEqualToMinBitMatrix32(dbm, dim, bitMatrix, &nbConstraints, mingraph);
+    bool retVal = mingraph_isAnalyzedDBMEqualToMinBitMatrix32(dbm, dim, bitMatrix, &nbConstraints, mingraph);
+    free(bitMatrix);
+    return retVal;
 }
 
 /* Compare a DBM with a stored DBM in the format
@@ -353,9 +355,11 @@ static bool mingraph_isAnalyzedDBMEqualToMinBitMatrix16(const raw_t* dbm, cindex
  */
 static bool mingraph_isEqualToMinBitMatrix16(const raw_t* dbm, cindex_t dim, const int32_t* mingraph)
 {
-    uint32_t bitMatrix[bits2intsize(dim * dim)];
+    uint32_t* bitMatrix = (uint32_t*)calloc(bits2intsize(dim * dim), sizeof(uint32_t));
     size_t nbConstraints = dbm_analyzeForMinDBM(dbm, dim, bitMatrix);
-    return mingraph_isAnalyzedDBMEqualToMinBitMatrix16(dbm, dim, bitMatrix, &nbConstraints, mingraph);
+    bool retVal = mingraph_isAnalyzedDBMEqualToMinBitMatrix16(dbm, dim, bitMatrix, &nbConstraints, mingraph);
+    free(bitMatrix);
+    return retVal;
 }
 
 /* Compare a DBM with a stored DBM in the format
@@ -442,9 +446,11 @@ static bool mingraph_isAnalyzedDBMEqualToMinCouplesij32(const raw_t* dbm, cindex
  */
 static bool mingraph_isEqualToMinCouplesij32(const raw_t* dbm, cindex_t dim, const int32_t* mingraph)
 {
-    uint32_t bitMatrix[bits2intsize(dim * dim)];
+    uint32_t* bitMatrix = (uint32_t*)calloc(bits2intsize(dim * dim), sizeof(uint32_t));
     size_t nbConstraints = dbm_analyzeForMinDBM(dbm, dim, bitMatrix);
-    return mingraph_isAnalyzedDBMEqualToMinCouplesij32(dbm, dim, bitMatrix, &nbConstraints, mingraph);
+    bool retVal = mingraph_isAnalyzedDBMEqualToMinCouplesij32(dbm, dim, bitMatrix, &nbConstraints, mingraph);
+    free(bitMatrix);
+    return retVal;
 }
 
 /* Compare a DBM with a stored DBM in the format
@@ -529,9 +535,11 @@ static bool mingraph_isAnalyzedDBMEqualToMinCouplesij16(const raw_t* dbm, cindex
  */
 static bool mingraph_isEqualToMinCouplesij16(const raw_t* dbm, cindex_t dim, const int32_t* mingraph)
 {
-    uint32_t bitMatrix[bits2intsize(dim * dim)];
+    uint32_t* bitMatrix = (uint32_t*)calloc(bits2intsize(dim * dim), sizeof(uint32_t));
     size_t nbConstraints = dbm_analyzeForMinDBM(dbm, dim, bitMatrix);
-    return mingraph_isAnalyzedDBMEqualToMinCouplesij16(dbm, dim, bitMatrix, &nbConstraints, mingraph);
+    bool retVal = mingraph_isAnalyzedDBMEqualToMinCouplesij16(dbm, dim, bitMatrix, &nbConstraints, mingraph);
+    free(bitMatrix);
+    return retVal;
 }
 
 /* Fatal error: should not be called.

--- a/src/mingraph_read.c
+++ b/src/mingraph_read.c
@@ -337,11 +337,11 @@ static cindex_t mingraph_readFromMinBitMatrix32(raw_t* dbm, const int32_t* mingr
     cindex_t i = 0, j = 0;
 
 #ifdef EXPERIMENTAL
-    uint32_t indices[dim * (dim - 1)];
+    uint32_t* indices = (uint32_t*)calloc(dim * (dim - 1), sizeof(uint32_t));
     size_t ni = 0;
 #else
     /* keep track of touched clocks */
-    uint32_t touched[bits2intsize(dim)];
+    uint32_t* touched = (uint32_t*)calloc(bits2intsize(dim), sizeof(uint32_t));
     base_resetBits(touched, bits2intsize(dim));
 #endif
 
@@ -370,6 +370,7 @@ static cindex_t mingraph_readFromMinBitMatrix32(raw_t* dbm, const int32_t* mingr
             if (!--nbConstraints) {
                 if (ni)
                     mingraph_close(indices, ni, dbm, dim);
+                free(indices);
                 return dim;
             }
 #else
@@ -381,6 +382,7 @@ static cindex_t mingraph_readFromMinBitMatrix32(raw_t* dbm, const int32_t* mingr
             if (!--nbConstraints) /* no constraint left */
             {
                 dbm_closex(dbm, dim, touched);
+                free(touched);
                 return dim;
             }
 #endif
@@ -409,12 +411,11 @@ static cindex_t mingraph_readFromMinBitMatrix16(raw_t* dbm, const int32_t* mingr
     cindex_t i = 0, j = 0;
 
 #ifdef EXPERIMENTAL
-    uint32_t indices[dim * (dim - 1)];
+    uint32_t* indices = (uint32_t*)calloc(dim * (dim - 1), sizeof(uint32_t));
     size_t ni = 0;
 #else
     /* keep track of touched clocks */
-    uint32_t touched[bits2intsize(dim)];
-    base_resetBits(touched, bits2intsize(dim));
+    uint32_t* touched = (uint32_t*)calloc(bits2intsize(dim), sizeof(uint32_t));
 #endif
 
     assert(dbm && dim > 2);
@@ -442,6 +443,7 @@ static cindex_t mingraph_readFromMinBitMatrix16(raw_t* dbm, const int32_t* mingr
             if (!--nbConstraints) {
                 if (ni)
                     mingraph_close(indices, ni, dbm, dim);
+                free(indices);
                 return dim;
             }
 #else
@@ -453,6 +455,7 @@ static cindex_t mingraph_readFromMinBitMatrix16(raw_t* dbm, const int32_t* mingr
             if (!--nbConstraints) /* no constraint left */
             {
                 dbm_closex(dbm, dim, touched);
+                free(touched);
                 return dim;
             }
 #endif
@@ -495,12 +498,11 @@ static cindex_t mingraph_readFromMinCouplesij32(raw_t* dbm, const int32_t* mingr
         uint32_t val_ij = *couplesij;
 
 #ifdef EXPERIMENTAL
-        uint32_t indices[dim * (dim - 1)];
+        uint32_t* indices = (uint32_t*)calloc(dim * (dim - 1), sizeof(uint32_t));
         size_t ni = 0;
 #else
         /* keep track of touched clocks */
-        uint32_t touched[bits2intsize(dim)];
-        base_resetBits(touched, bits2intsize(dim));
+        uint32_t* touched = (uint32_t*)calloc(bits2intsize(dim), sizeof(uint32_t));
 #endif
 
         for (;;) {
@@ -552,8 +554,10 @@ static cindex_t mingraph_readFromMinCouplesij32(raw_t* dbm, const int32_t* mingr
 #ifdef EXPERIMENTAL
         if (ni)
             mingraph_close(indices, ni, dbm, dim);
+        free(indices);
 #else
         dbm_closex(dbm, dim, touched);
+        free(touched);
 #endif
     }
     return dim;
@@ -584,12 +588,11 @@ static cindex_t mingraph_readFromMinCouplesij16(raw_t* dbm, const int32_t* mingr
     uint32_t val_ij = *couplesij;
 
 #ifdef EXPERIMENTAL
-    uint32_t indices[dim * (dim - 1)];
+    uint32_t* indices = (uint32_t*)calloc(dim * (dim - 1), sizeof(uint32_t));
     size_t ni = 0;
 #else
     /* keep track of touched clocks */
-    uint32_t touched[bits2intsize(dim)];
-    base_resetBits(touched, bits2intsize(dim));
+    uint32_t* touched = (uint32_t*)calloc(bits2intsize(dim), sizeof(uint32_t));
 #endif
 
     assert(nbConstraints); /* can't be = 0 */
@@ -638,8 +641,10 @@ static cindex_t mingraph_readFromMinCouplesij16(raw_t* dbm, const int32_t* mingr
 #ifdef EXPERIMENTAL
     if (ni)
         mingraph_close(indices, ni, dbm, dim);
+    free(indices);
 #else
     dbm_closex(dbm, dim, touched);
+    free(touched);
 #endif
     return dim;
 }
@@ -693,8 +698,8 @@ static size_t mingraph_addMissingConstraints(uint32_t* matrix, const int32_t* mi
     }
 
     /* See analyseForMinDBM */
-    cindex_t first[dim + dim];    /* cindex_t[dim] */
-    cindex_t* next = first + dim; /* cindex_t[dim] */
+    cindex_t* first = (cindex_t*)calloc(dim + dim, sizeof(cindex_t)); /* cindex_t[dim] */
+    cindex_t* next = first + dim;                                     /* cindex_t[dim] */
     cindex_t *q, *r, *end = first;
     const raw_t* dbm_idim = dbm; /* dbm[i*dim] */
     cindex_t i, j, k;
@@ -746,6 +751,7 @@ static size_t mingraph_addMissingConstraints(uint32_t* matrix, const int32_t* mi
         nbConstraints += mingraph_ngetAndSetBit(matrix, next[0]);
     }
 
+    free(first);
     return nbConstraints;
 }
 

--- a/src/priced.cpp
+++ b/src/priced.cpp
@@ -352,10 +352,10 @@ static int32_t infOfDiff(const raw_t* dbm, uint32_t dim, int32_t cost1, const in
     assert(dbm && dim && rate1 && rate2);
 
     int32_t cost = cost1 - cost2;
-    int32_t rates[dim];
-    std::transform(rate1, rate1 + dim, rate2, rates, std::minus<int32_t>());
+    std::vector<int32_t> rates(dim);
+    std::transform(rate1, rate1 + dim, rate2, rates.data(), std::minus<int32_t>());
 
-    return pdbm_infimum(dbm, dim, cost, rates);
+    return pdbm_infimum(dbm, dim, cost, rates.data());
 }
 
 relation_t pdbm_relation(const PDBM pdbm1, const PDBM pdbm2, cindex_t dim)
@@ -577,7 +577,7 @@ int32_t pdbm_getInfimumValuation(const PDBM pdbm, cindex_t dim, int32_t* valuati
     assert(pdbm && dim && valuation);
     assert(pdbm_isValid(pdbm, dim));
 
-    raw_t copy[dim * dim];
+    std::vector<raw_t> copy(dim * dim);
     raw_t* dbm = pdbm_matrix(pdbm);
     int32_t* rates = pdbm_rates(pdbm);
 
@@ -592,8 +592,8 @@ int32_t pdbm_getInfimumValuation(const PDBM pdbm, cindex_t dim, int32_t* valuati
      * according to the valuation given.
      */
     if (free) {
-        dbm_copy(copy, dbm, dim);
-        dbm = copy;
+        dbm_copy(copy.data(), dbm, dim);
+        dbm = copy.data();
 
         for (uint32_t i = 1; i < dim; i++) {
             if (!free[i]) {
@@ -1016,7 +1016,7 @@ uint32_t pdbm_getLowerRelativeFacets(PDBM& pdbm, cindex_t dim, cindex_t clock, c
 {
     assert(pdbm && dim && clock < dim);
 
-    cindex_t next[dim];
+    std::vector<cindex_t> next(dim);
     cindex_t i;
 
     pdbm_prepare(pdbm, dim);
@@ -1029,13 +1029,13 @@ uint32_t pdbm_getLowerRelativeFacets(PDBM& pdbm, cindex_t dim, cindex_t clock, c
 
     /* Identify zero cycles.
      */
-    dbm_findZeroCycles(dbm, dim, next);
+    dbm_findZeroCycles(dbm, dim, next.data());
 
     /* Find non-redundant facets.
      */
     uint32_t cnt = 0;
     for (i = 0; i < dim; i++) {
-        if (!next[i] && !isRedundant(dbm, dim, i, clock, next)) {
+        if (!next[i] && !isRedundant(dbm, dim, i, clock, next.data())) {
             *facets = i;
             facets++;
             cnt++;
@@ -1048,7 +1048,7 @@ uint32_t pdbm_getUpperRelativeFacets(PDBM& pdbm, cindex_t dim, cindex_t clock, c
 {
     assert(pdbm && dim && clock < dim && facets);
 
-    cindex_t next[dim];
+    std::vector<cindex_t> next(dim);
     cindex_t i;
 
     pdbm_prepare(pdbm, dim);
@@ -1061,13 +1061,13 @@ uint32_t pdbm_getUpperRelativeFacets(PDBM& pdbm, cindex_t dim, cindex_t clock, c
 
     /* Identify zero cycles.
      */
-    dbm_findZeroCycles(dbm, dim, next);
+    dbm_findZeroCycles(dbm, dim, next.data());
 
     /* Find non-redundant facets.
      */
     uint32_t cnt = 0;
     for (i = 0; i < dim; i++) {
-        if (!next[i] && !isRedundant(dbm, dim, clock, i, next)) {
+        if (!next[i] && !isRedundant(dbm, dim, clock, i, next.data())) {
             *facets = i;
             facets++;
             cnt++;
@@ -1080,7 +1080,7 @@ uint32_t pdbm_getLowerFacets(PDBM& pdbm, cindex_t dim, cindex_t* facets)
 {
     assert(pdbm && dim && facets);
 
-    cindex_t next[dim];
+    std::vector<cindex_t> next(dim);
     cindex_t i;
 
     pdbm_prepare(pdbm, dim);
@@ -1093,13 +1093,13 @@ uint32_t pdbm_getLowerFacets(PDBM& pdbm, cindex_t dim, cindex_t* facets)
 
     /* Identify zero cycles.
      */
-    dbm_findZeroCycles(dbm, dim, next);
+    dbm_findZeroCycles(dbm, dim, next.data());
 
     /* Find non-redundant facets.
      */
     uint32_t cnt = 0;
     for (i = 0; i < dim; i++) {
-        if (!next[i] && !isRedundant(dbm, dim, 0, i, next)) {
+        if (!next[i] && !isRedundant(dbm, dim, 0, i, next.data())) {
             *facets = i;
             facets++;
             cnt++;
@@ -1112,7 +1112,7 @@ uint32_t pdbm_getUpperFacets(PDBM& pdbm, cindex_t dim, cindex_t* facets)
 {
     assert(pdbm && dim && facets);
 
-    cindex_t next[dim];
+    std::vector<cindex_t> next(dim);
     cindex_t i;
 
     pdbm_prepare(pdbm, dim);
@@ -1125,13 +1125,13 @@ uint32_t pdbm_getUpperFacets(PDBM& pdbm, cindex_t dim, cindex_t* facets)
 
     /* Identify zero cycles.
      */
-    dbm_findZeroCycles(dbm, dim, next);
+    dbm_findZeroCycles(dbm, dim, next.data());
 
     /* Find non-redundant facets.
      */
     uint32_t cnt = 0;
     for (i = 0; i < dim; i++) {
-        if (!next[i] && !isRedundant(dbm, dim, i, 0, next)) {
+        if (!next[i] && !isRedundant(dbm, dim, i, 0, next.data())) {
             *facets = i;
             facets++;
             cnt++;
@@ -1305,11 +1305,11 @@ void pdbm_freeDown(PDBM& pdbm, cindex_t dim, cindex_t index)
 void pdbm_normalise(PDBM pdbm, cindex_t dim)
 {
     int32_t* rates = pdbm_rates(pdbm);
-    cindex_t next[dim];
+    std::vector<cindex_t> next(dim);
     cindex_t i;
 
     assert(dim > 0);
-    dbm_findZeroCycles(pdbm_matrix(pdbm), dim, next);
+    dbm_findZeroCycles(pdbm_matrix(pdbm), dim, next.data());
 
     /* Everything in the equivalence class of 0 will have rate 0.
      */
@@ -1331,11 +1331,11 @@ void pdbm_normalise(PDBM pdbm, cindex_t dim)
 bool pdbm_hasNormalForm(PDBM pdbm, cindex_t dim)
 {
     int32_t* rates = pdbm_rates(pdbm);
-    cindex_t next[dim];
+    std::vector<cindex_t> next(dim);
     cindex_t i;
 
     assert(dim > 0);
-    dbm_findZeroCycles(pdbm_matrix(pdbm), dim, next);
+    dbm_findZeroCycles(pdbm_matrix(pdbm), dim, next.data());
 
     /* Everything in the equivalence class of 0 will have rate 0.
      */

--- a/test/test_dbm.c
+++ b/test/test_dbm.c
@@ -64,8 +64,6 @@
 /* Allocation of DBM, vector, bitstring
  */
 #define ADBM(NAME)  raw_t* NAME = allocDBM(size)
-#define AVECT(NAME) int32_t NAME[size]
-#define ABITS(NAME) uint32_t NAME[bits2intsize(size)]
 #define DVECT(NAME) double NAME[size]
 
 /* Random range
@@ -99,7 +97,7 @@ static uint32_t goodDBMs = 0;
 static void test_zero(uint32_t size)
 {
     ADBM(dbm);
-    AVECT(pt);
+    uint32_t* pt = (uint32_t*)calloc(size, sizeof(uint32_t));
     uint32_t k;
     PRINTF("zero");
     dbm_zero(dbm, size);
@@ -114,6 +112,7 @@ static void test_zero(uint32_t size)
     }
 
     ENDL;
+    free(pt);
     free(dbm);
 }
 
@@ -485,10 +484,10 @@ static void test_constrain(uint32_t size)
     ADBM(dbm3);
     ADBM(dbm4);
     ADBM(dbm5);
-    AVECT(pt);
-    ABITS(touched1);
-    ABITS(touched2);
-    ABITS(touched3);
+    uint32_t* pt = (uint32_t*)calloc(size, sizeof(uint32_t));
+    uint32_t* touched1 = (uint32_t*)calloc(bits2intsize(size), sizeof(uint32_t));
+    uint32_t* touched2 = (uint32_t*)calloc(bits2intsize(size), sizeof(uint32_t));
+    uint32_t* touched3 = (uint32_t*)calloc(bits2intsize(size), sizeof(uint32_t));
     constraint_t* constraints = (constraint_t*)malloc(size * size * sizeof(constraint_t));
     uint32_t k;
     PRINTF("constrain+constrain1+constrainN+satisfy+isEmpty+close+closex+close1");
@@ -588,7 +587,11 @@ static void test_constrain(uint32_t size)
     }
 
     ENDL;
+    free(touched1);
+    free(touched2);
+    free(touched3);
     free(constraints);
+    free(pt);
     free(dbm5);
     free(dbm4);
     free(dbm3);
@@ -601,7 +604,7 @@ static void test_constrain(uint32_t size)
 static void test_point(uint32_t size)
 {
     ADBM(dbm1);
-    AVECT(pt);
+    uint32_t* pt = (uint32_t*)calloc(size, sizeof(uint32_t));
     uint32_t i, k;
     PRINTF("discrete point");
 
@@ -618,6 +621,7 @@ static void test_point(uint32_t size)
     }
 
     ENDL;
+    free(pt);
     free(dbm1);
 }
 
@@ -626,7 +630,7 @@ static void test_point(uint32_t size)
 static void test_real_point(uint32_t size)
 {
     ADBM(dbm1);
-    DVECT(pt);
+    double* pt = (double*)calloc(size, sizeof(double));
     uint32_t i, k;
     PRINTF("real point");
 
@@ -644,6 +648,7 @@ static void test_real_point(uint32_t size)
     }
 
     ENDL;
+    free(pt);
     free(dbm1);
 }
 

--- a/test/test_ext.c
+++ b/test/test_ext.c
@@ -103,11 +103,11 @@ static void test_shrinkExpand(uint32_t dim)
 {
     uint32_t intSize = bits2intsize(dim);
     uint32_t tableSize = intSize * 32;
-    cindex_t srcTable[tableSize];
-    cindex_t dstTable[tableSize];
-    cindex_t checkTable[tableSize];
-    uint32_t bitString1[intSize];
-    uint32_t bitString2[intSize];
+    cindex_t* srcTable = (cindex_t*)calloc(tableSize, sizeof(cindex_t));
+    cindex_t* dstTable = (cindex_t*)calloc(tableSize, sizeof(cindex_t));
+    cindex_t* checkTable = (cindex_t*)calloc(tableSize, sizeof(cindex_t));
+    uint32_t* bitString1 = (uint32_t*)calloc(intSize, sizeof(uint32_t));
+    uint32_t* bitString2 = (uint32_t*)calloc(intSize, sizeof(uint32_t));
     raw_t* dbm1 = allocDBM(dim);
     raw_t* dbm2 = allocDBM(dim);
     uint32_t k;
@@ -147,7 +147,9 @@ static void test_shrinkExpand(uint32_t dim)
             assert(dbm_isValid(dbm2, dim2));
 
             /* check table */
-            assert(base_areEqual(dstTable, checkTable, intSizeOf(cindex_t[dim])));
+            cindex_t* someArray = (cindex_t*)calloc(dim, sizeof(cindex_t));
+            assert(base_areEqual(dstTable, checkTable, intSizeOf(someArray)));
+            free(someArray);
 
             for (i = 0; i < dim; ++i) {
                 for (j = 0; j < dim; ++j) {
@@ -181,7 +183,11 @@ static void test_shrinkExpand(uint32_t dim)
         }
         */
     }
-
+    free(srcTable);
+    free(dstTable);
+    free(checkTable);
+    free(bitString1);
+    free(bitString2);
     free(dbm2);
     free(dbm1);
 }

--- a/test/test_fed_dbm.cpp
+++ b/test/test_fed_dbm.cpp
@@ -75,7 +75,8 @@ static void test(cindex_t dim)
     NEW(dbm);
     NEW(dbm2);
     constraint_t* cnstr = new constraint_t[dim * dim];
-    int32_t lower[dim], upper[dim];
+    std::vector<int32_t> lower(dim);
+    std::vector<int32_t> upper(dim);
     IntValuation pt(dim);
     // coverage
     bool c1 = false, c2 = false, c4 = false;
@@ -455,20 +456,20 @@ static void test(cindex_t dim)
         a.copyTo(dbm, dim);
         switch (k) {
         case 0:
-            b.extrapolateMaxBounds(upper);
-            dbm_extrapolateMaxBounds(dbm, dim, upper);
+            b.extrapolateMaxBounds(upper.data());
+            dbm_extrapolateMaxBounds(dbm, dim, upper.data());
             break;
         case 1:
-            b.diagonalExtrapolateMaxBounds(upper);
-            dbm_diagonalExtrapolateMaxBounds(dbm, dim, upper);
+            b.diagonalExtrapolateMaxBounds(upper.data());
+            dbm_diagonalExtrapolateMaxBounds(dbm, dim, upper.data());
             break;
         case 2:
-            b.extrapolateLUBounds(lower, upper);
-            dbm_extrapolateLUBounds(dbm, dim, lower, upper);
+            b.extrapolateLUBounds(lower.data(), upper.data());
+            dbm_extrapolateLUBounds(dbm, dim, lower.data(), upper.data());
             break;
         case 3:
-            b.diagonalExtrapolateLUBounds(lower, upper);
-            dbm_diagonalExtrapolateLUBounds(dbm, dim, lower, upper);
+            b.diagonalExtrapolateLUBounds(lower.data(), upper.data());
+            dbm_diagonalExtrapolateLUBounds(dbm, dim, lower.data(), upper.data());
             break;
         }
         assert(b == dbm && a <= b);

--- a/test/test_mingraph.c
+++ b/test/test_mingraph.c
@@ -127,7 +127,8 @@ static void test(size_t dim, bool tryBest)
     int32_t stats[dbm_MINDBM_ERROR + 1];
     uint32_t sizes[dbm_MINDBM_ERROR + 1];
     size_t testSize = bits2intsize(dim * dim), nbCons1, nbCons2;
-    uint32_t testMG1[testSize], testMG2[testSize];
+    uint32_t* testMG1 = (uint32_t*)calloc(testSize, sizeof(uint32_t));
+    uint32_t* testMG2 = (uint32_t*)calloc(testSize, sizeof(uint32_t));
 
     printf("** Testing size=%zu **\n", dim);
 
@@ -276,6 +277,8 @@ static void test(size_t dim, bool tryBest)
     free(dbm3);
     free(dbm2);
     free(dbm1);
+    free(testMG1);
+    free(testMG2);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Testing it in UPPAAL, it does not seem to have any noticable performance impact to exchange the VLA arrays with `calloc` calls. This is probably because most of the arrays allocated in this manner are unallocated almost immediately after, which lets glibc use the cache very efficiently. 