### PR TITLE
Re-enable federation tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           export CTEST_OUTPUT_ON_FAILURE=1
           mkdir build
           cd build
-          cmake -DTESTING=yes -DSTATIC=$STATIC  -DASAN=${{ matrix.asan }} -DUBSAN=${{ matrix.ubsan }} ..
+          cmake -DTESTING=yes -DSTATIC=$STATIC  -DASAN=${{ matrix.asan }} -DUBSAN=${{ matrix.ubsan }} -DCMAKE_BUILD_TYPE=Release ..
           cmake --build .
           ctest
   build-macos:
@@ -78,7 +78,7 @@ jobs:
           export CTEST_OUTPUT_ON_FAILURE=1
           mkdir build
           cd build
-          cmake -DTESTING=yes -DASAN=${{ matrix.asan }} -DUBSAN=${{ matrix.ubsan }} ..
+          cmake -DTESTING=yes -DASAN=${{ matrix.asan }} -DUBSAN=${{ matrix.ubsan }} -DCMAKE_BUILD_TYPE=Release ..
           cmake --build .
           ctest
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ compile_commands.json
 *.log
 *.pdf
 *.toc
+
+# Flakes and direnv
+.direnv
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /build
 /libs
-src/config.h
 compile_commands.json
 
 # Manual

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1646011258,
+        "narHash": "sha256-+aen4zu5uVp52arEcgL2maCS0zQDuG1t+Azwd/O1gN4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a25df4c2b79c4343bcc72ad671200e5a3e286c41",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "UPPAAL DBM Library";
+
+  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+
+  outputs = { self, nixpkgs }:
+  let
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+  in
+  {
+    packages = forAllSystems (system:
+    let
+      pkgs = nixpkgsFor.${system};
+    in
+    {
+      UDBM = pkgs.stdenv.mkDerivation {
+        pname = "UDBM";
+        version = "0.0.0";
+        src = ./.;
+      };
+    });
+    devShell = forAllSystems (system:
+    let pkgs = nixpkgsFor.${system};
+    in pkgs.mkShell {
+      buildInputs = with pkgs; [ cmake doctest boost ninja ];
+    });
+  };
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,12 +31,10 @@ if (TESTING)
   if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 	  set_tests_properties(
-	    dbm_fed_1_7_7        # 3m16s and then assertion fail
 	    dbm_mingraph_1_10 dbm_mingraph_1_10_1 # assertion fail
 	    PROPERTIES DISABLED TRUE)
     elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
 	  set_tests_properties(
-	    dbm_fed_1_7_7        # 40m22s and then passes(!)
 	    dbm_mingraph_1_10    # assertion fail
 	    dbm_mingraph_1_10_1  # assertion fail
 	    PROPERTIES DISABLED TRUE)
@@ -44,18 +42,12 @@ if (TESTING)
   elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 	  set_tests_properties(
-	    dbm_fed_1_7_7        # 3m16s and then assertion fail
 	    dbm_mingraph_1_10 dbm_mingraph_1_10_1 # assertion fail
 	    PROPERTIES DISABLED TRUE)
     endif()
   elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
 	  set_tests_properties(
-	    dbm_fed_1_7_7        # 7m17s and then assertion fail
-	    PROPERTIES DISABLED TRUE)
-    elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
-	  set_tests_properties(
-	    dbm_fed_1_7_7        # 28m52s and then passes(!)
 	    dbm_mingraph_1_10 dbm_mingraph_1_10_1 # assertion fail
 	    PROPERTIES DISABLED TRUE)
     endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,8 @@ if (TESTING)
   set_tests_properties(dbm_mingraph_1_10_1 PROPERTIES TIMEOUT 45) # 39s on Win64
   add_test(NAME dbm_valuation_20    COMMAND test_valuation 20)
 
+  set_tests_properties(dbm_dbm_1_10 PROPERTIES TIMEOUT 180)
+
   # disable failing tests:
   if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,7 +25,7 @@ if (TESTING)
   set_tests_properties(dbm_mingraph_1_10_1 PROPERTIES TIMEOUT 45) # 39s on Win64
   add_test(NAME dbm_valuation_20    COMMAND test_valuation 20)
 
-  set_tests_properties(dbm_dbm_1_10 PROPERTIES TIMEOUT 180)
+  set_tests_properties(dbm_dbm_1_10 dbm_fed_1_7_7 PROPERTIES TIMEOUT 1200)
 
   # disable failing tests:
   if (CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/test/test_fed.cpp
+++ b/test/test_fed.cpp
@@ -454,6 +454,12 @@ static void test_convexUnion(cindex_t dim, size_t size)
 // test &= intersection
 static void test_intersection(cindex_t dim, size_t size)
 {
+    /**
+     * This test was originally written using floating point clock valuations instead of integers
+     * This caused the issues described in tests/test_fp_intersection.cpp. For more information,
+     * git blame this comment
+     * TODO: Make intersection of DBMs behave properly with floating point numbers
+     */
     SHOW_TEST();
     uint32_t k;
     for (k = 0; k < NB_LOOPS; ++k) {
@@ -1165,7 +1171,7 @@ static void test_subtract(cindex_t dim, size_t size)
         uint32_t h1 = fed1.hash();
         uint32_t h2 = fed2.hash();
         fed_t fed4 = fed1 & fed2;
-        double pt[dim];
+        int pt[dim];
         assert(fed4.le(fed1) && fed4.le(fed2));
         assert((fed4 - fed1).isEmpty());
         assert((fed4 - fed2).isEmpty());
@@ -1193,25 +1199,25 @@ static void test_subtract(cindex_t dim, size_t size)
         }
         assert(fed3.eq(fed1));
         for (int count = 0; count < 500; ++count) {
-            if (test_generateRealPoint(pt, fed1))  // points in fed1 not in fed2
+            if (test_generatePoint(pt, fed1))  // points in fed1 not in fed2
             {
-                assert(test_isRealPointIn(pt, fed1, dim));
+                assert(test_isPointIn(pt, fed1, dim));
                 assert(fed1.contains(pt, dim));
-                assert(!test_isRealPointIn(pt, fed2, dim));
+                assert(!test_isPointIn(pt, fed2, dim));
                 assert(!fed2.contains(pt, dim));
             }
-            if (test_generateRealPoint(pt, fed2))  // points in fed2 not in fed1
+            if (test_generatePoint(pt, fed2))  // points in fed2 not in fed1
             {
-                assert(test_isRealPointIn(pt, fed2, dim));
+                assert(test_isPointIn(pt, fed2, dim));
                 assert(fed2.contains(pt, dim));
-                assert(!test_isRealPointIn(pt, fed1, dim));
+                assert(!test_isPointIn(pt, fed1, dim));
                 assert(!fed1.contains(pt, dim));
             }
-            if (test_generateRealPoint(pt, fed4))  // points in fed4 not in fed1
+            if (test_generatePoint(pt, fed4))  // points in fed4 not in fed1
             {
-                assert(test_isRealPointIn(pt, fed4, dim));
+                assert(test_isPointIn(pt, fed4, dim));
                 assert(fed4.contains(pt, dim));
-                assert(!test_isRealPointIn(pt, fed1, dim));
+                assert(!test_isPointIn(pt, fed1, dim));
                 assert(!fed1.contains(pt, dim));
             }
         }

--- a/test/test_fp_intersection.cpp
+++ b/test/test_fp_intersection.cpp
@@ -1,0 +1,87 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include "dbm/dbm.h"
+#include "dbm/print.h"
+#include "base/doubles.h"
+
+#include <iostream>
+#include <limits>
+#include <cmath>
+#include <cstdint>
+
+void printConstraint(const raw_t constraint, const double i, const double j)
+{
+    std::cout << i << (dbm_rawIsStrict(constraint) ? "<" : "<=") << j << "+" << dbm_raw2bound(constraint) << std::endl;
+}
+
+#define DBM(I, J) dbm[(I)*dim + (J)]
+void printViolatingConstraint(const raw_t* dbm, const double* pt, const uint32_t dim)
+{
+    cindex_t i, j;
+    for (i = 0; i < dim; ++i) {
+        for (j = 0; j < dim; ++j) {
+            if (DBM(i, j) < dbm_LS_INFINITY) {
+                double bound = dbm_raw2bound(DBM(i, j));
+                /* if strict: !(pi-pj < bij) -> false
+                 * if weak  : !(pi-pj <= bij) -> false
+                 */
+                if (dbm_rawIsStrict(DBM(i, j))) {
+                    // if (pt[i] >= pt[j]+bound) return false;
+                    if (IS_GE(pt[i], pt[j] + bound))
+                        printConstraint(DBM(i, j), pt[i], pt[j]);
+                } else {
+                    // if (pt[i] > pt[j]+bound) return false;
+                    if (IS_GT(pt[i], pt[j] + bound))
+                        printConstraint(DBM(i, j), pt[i], pt[j]);
+                }
+            }
+        }
+    }
+}
+
+int main()
+{
+    const size_t dim = 3;
+    const raw_t dbm1[] = {dbm_boundbool2raw(0, false),   dbm_boundbool2raw(-8, true),  dbm_boundbool2raw(-182, true),
+                          dbm_boundbool2raw(86, true),   dbm_boundbool2raw(0, false),  dbm_boundbool2raw(-174, true),
+                          dbm_boundbool2raw(445, false), dbm_boundbool2raw(400, true), dbm_boundbool2raw(0, false)};
+    const raw_t dbm2[] = {dbm_boundbool2raw(0, false),   dbm_boundbool2raw(-8, true),   dbm_boundbool2raw(-182, true),
+                          dbm_boundbool2raw(10, false),  dbm_boundbool2raw(0, false),   dbm_boundbool2raw(-174, false),
+                          dbm_boundbool2raw(184, false), dbm_boundbool2raw(174, false), dbm_boundbool2raw(0, false)};
+
+    double x = 8.9844974150810408;
+    double y = 182.98449741508105;
+    const double pt[] = {0, x, y};
+
+    std::cout.precision(std::numeric_limits<double>::max_digits10);
+    std::cout << "DBMs exhibit some unexpected behaviour when it comes to doubles and intersections" << std::endl;
+    std::cout << "Consider the following DBMS:" << std::endl;
+    std::cout << "DBM 1:" << std::endl;
+    dbm_cppPrint(std::cout, dbm1, dim);
+    std::cout << std::endl << "DBM 2:" << std::endl;
+    dbm_cppPrint(std::cout, dbm2, dim);
+    std::cout << std::endl
+              << "DBM 1 corresponds to the set of clock valuations {(0, x, y) | 8 < x < 86, 182 < y <= 445, x + 174 < "
+                 "y < x + 437}"
+              << std::endl;
+    std::cout
+        << std::endl
+        << "DBM 2 corresponds to the set of clock valuations {(0, x, y) | 8 < x <= 10, 182 < y < 184, x - y == -174}"
+        << std::endl;
+    std::cout << "Since the constraints x - y == -174 and x + 174 < y, the two DBMs should have no intersection."
+              << std::endl;
+    std::cout << "But consider the valuation [0, " << pt[1] << ", " << pt[2] << "]" << std::endl;
+    std::cout << pt[1] << " - " << pt[2] << " = " << pt[1] - pt[2] << std::endl;
+    std::cout << pt[1] << " < " << pt[2] << " - 174 = " << ((pt[1] < pt[2] - 174) ? "true" : "false") << std::endl;
+    std::cout
+        << "This finicky behaviour in doubles basically allows us to have a series of points which exist in both DBMs:"
+        << std::endl;
+    std::cout << "assert(dbm_isRealPointIncluded(pt, dbm1, dim));" << std::endl;
+    assert(dbm_isRealPointIncluded(pt, dbm1, dim));
+    std::cout << "assert(dbm_isRealPointIncluded(pt, dbm2, dim));" << std::endl;
+    assert(dbm_isRealPointIncluded(pt, dbm2, dim));
+    std::cout << "assert(!dbm_haveIntersection(dbm1, dbm2, dim));" << std::endl;
+    assert(!dbm_haveIntersection(dbm1, dbm2, dim));
+}


### PR DESCRIPTION
Also add a test `test_fp_intersection`, which shows why intersections of DBMs interacts with double points in a weird way. It also fixes the federation tests based on that.
Also:
 * Adds a Nix Flake
 * Increases the test timeout, this should stop intermittent crashing of the dbm test on macos in CI.
 * Builds in release mode on CI
 * Adds optimization flags to the build