### PR TITLE
Docs: Add hyperref, fix errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@ compile_commands.json
 *.log
 *.pdf
 *.toc
+*.bbl
+*.blg
+*.fdb_latexmk
+*.fls
+*.ilg
+*.ind
+*.out
 
 # Flakes and direnv
 .direnv

--- a/docs/manual.tex
+++ b/docs/manual.tex
@@ -1,6 +1,8 @@
 \documentclass[a4paper]{report}
 \usepackage{amsmath,amsfonts,amssymb,latexsym}
 \usepackage{graphicx,rotating,makeidx,xspace}
+\usepackage{hyperref}
+\usepackage[nottoc,notlot,notlof]{tocbibind}
 
 \newcommand{\forget}[1]{}
 \def \uppaal {{\sc Uppaal}}
@@ -71,8 +73,6 @@
 % ToC
 
 \tableofcontents
-\contentsline{chapter}{\numberline{}References}{\pageref{REF}}
-\contentsline{chapter}{\numberline{}Index}{\pageref{INDEX}}
 \newpage
 
 % Manual :)


### PR DESCRIPTION
Fixes two errors in the latex document, and adds hyperref.